### PR TITLE
Remove #[macro_export] from internal macros

### DIFF
--- a/src/fs/dir_builder.rs
+++ b/src/fs/dir_builder.rs
@@ -111,7 +111,7 @@ impl DirBuilder {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::fs::DirBuilderExt;
 
     impl DirBuilderExt for DirBuilder {

--- a/src/fs/dir_entry.rs
+++ b/src/fs/dir_entry.rs
@@ -158,7 +158,7 @@ impl fmt::Debug for DirEntry {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::fs::DirEntryExt;
 
     impl DirEntryExt for DirEntry {

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -399,7 +399,7 @@ impl From<std::fs::File> for File {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
     impl AsRawFd for File {
@@ -425,7 +425,7 @@ crate::cfg_unix! {
     }
 }
 
-crate::cfg_windows! {
+cfg_windows! {
     use crate::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
 
     impl AsRawHandle for File {

--- a/src/fs/file_type.rs
+++ b/src/fs/file_type.rs
@@ -1,8 +1,8 @@
-crate::cfg_not_docs! {
+cfg_not_docs! {
     pub use std::fs::FileType;
 }
 
-crate::cfg_docs! {
+cfg_docs! {
     /// The type of a file or directory.
     ///
     /// A file type is returned by [`Metadata::file_type`].

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -37,11 +37,11 @@ pub async fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     blocking::spawn(move || std::fs::metadata(path)).await
 }
 
-crate::cfg_not_docs! {
+cfg_not_docs! {
     pub use std::fs::Metadata;
 }
 
-crate::cfg_docs! {
+cfg_docs! {
     use std::time::SystemTime;
 
     use crate::fs::{FileType, Permissions};

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -294,7 +294,7 @@ impl Default for OpenOptions {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::fs::OpenOptionsExt;
 
     impl OpenOptionsExt for OpenOptions {

--- a/src/fs/permissions.rs
+++ b/src/fs/permissions.rs
@@ -1,8 +1,8 @@
-crate::cfg_not_docs! {
+cfg_not_docs! {
     pub use std::fs::Permissions;
 }
 
-crate::cfg_docs! {
+cfg_docs! {
     /// A set of permissions on a file or directory.
     ///
     /// This type is a re-export of [`std::fs::Permissions`].

--- a/src/future/future.rs
+++ b/src/future/future.rs
@@ -1,4 +1,4 @@
-crate::extension_trait! {
+extension_trait! {
     use std::pin::Pin;
     use std::ops::{Deref, DerefMut};
 

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -56,7 +56,7 @@ mod poll_fn;
 mod ready;
 mod timeout;
 
-crate::cfg_unstable! {
+cfg_unstable! {
     #[doc(inline)]
     pub use async_macros::{select, try_select};
 

--- a/src/io/buf_read/mod.rs
+++ b/src/io/buf_read/mod.rs
@@ -15,7 +15,7 @@ use std::pin::Pin;
 use crate::io;
 use crate::task::{Context, Poll};
 
-crate::extension_trait! {
+extension_trait! {
     use std::ops::{Deref, DerefMut};
 
     #[doc = r#"

--- a/src/io/read/mod.rs
+++ b/src/io/read/mod.rs
@@ -17,7 +17,7 @@ use std::mem;
 
 use crate::io::IoSliceMut;
 
-crate::extension_trait! {
+extension_trait! {
     use std::pin::Pin;
     use std::ops::{Deref, DerefMut};
 
@@ -303,34 +303,34 @@ crate::extension_trait! {
 
         #[doc = r#"
             Creates a "by reference" adaptor for this instance of `Read`.
-           
+
             The returned adaptor also implements `Read` and will simply borrow this
             current reader.
-           
+
             # Examples
-           
+
             [`File`][file]s implement `Read`:
-           
+
             [file]: ../fs/struct.File.html
-           
+
             ```no_run
             # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
             #
             use async_std::prelude::*;
             use async_std::fs::File;
-           
+
             let mut f = File::open("foo.txt").await?;
             let mut buffer = Vec::new();
             let mut other_buffer = Vec::new();
-           
+
             {
                 let reference = f.by_ref();
-           
+
                 // read at most 5 bytes
                 reference.take(5).read_to_end(&mut buffer).await?;
-           
+
             } // drop our &mut reference so we can use f again
-           
+
             // original file still usable, read the rest
             f.read_to_end(&mut other_buffer).await?;
             #
@@ -342,27 +342,27 @@ crate::extension_trait! {
 
         #[doc = r#"
             Transforms this `Read` instance to a `Stream` over its bytes.
-           
+
             The returned type implements `Stream` where the `Item` is
             `Result<u8, io::Error>`.
             The yielded item is `Ok` if a byte was successfully read and `Err`
             otherwise. EOF is mapped to returning `None` from this iterator.
-           
+
             # Examples
-           
+
             [`File`][file]s implement `Read`:
-           
+
             [file]: ../fs/struct.File.html
-           
+
             ```no_run
             # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
             #
             use async_std::prelude::*;
             use async_std::fs::File;
-           
+
             let f = File::open("foo.txt").await?;
             let mut s = f.bytes();
-           
+
             while let Some(byte) = s.next().await {
                 println!("{}", byte.unwrap());
             }
@@ -376,29 +376,29 @@ crate::extension_trait! {
 
         #[doc = r#"
             Creates an adaptor which will chain this stream with another.
-           
+
             The returned `Read` instance will first read all bytes from this object
             until EOF is encountered. Afterwards the output is equivalent to the
             output of `next`.
-           
+
             # Examples
-           
+
             [`File`][file]s implement `Read`:
-           
+
             [file]: ../fs/struct.File.html
-           
+
             ```no_run
             # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
             #
             use async_std::prelude::*;
             use async_std::fs::File;
-           
+
             let f1 = File::open("foo.txt").await?;
             let f2 = File::open("bar.txt").await?;
-           
+
             let mut handle = f1.chain(f2);
             let mut buffer = String::new();
-           
+
             // read the value into a String. We could use any Read method here,
             // this is just one example.
             handle.read_to_string(&mut buffer).await?;

--- a/src/io/seek/mod.rs
+++ b/src/io/seek/mod.rs
@@ -4,7 +4,7 @@ use seek::SeekFuture;
 
 use crate::io::SeekFrom;
 
-crate::extension_trait! {
+extension_trait! {
     use std::ops::{Deref, DerefMut};
     use std::pin::Pin;
 

--- a/src/io/stderr.rs
+++ b/src/io/stderr.rs
@@ -160,7 +160,7 @@ impl Write for Stderr {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::io::{AsRawFd, RawFd};
 
     impl AsRawFd for Stderr {
@@ -170,7 +170,7 @@ crate::cfg_unix! {
     }
 }
 
-crate::cfg_windows! {
+cfg_windows! {
     use crate::os::windows::io::{AsRawHandle, RawHandle};
 
     impl AsRawHandle for Stderr {

--- a/src/io/stdin.rs
+++ b/src/io/stdin.rs
@@ -184,7 +184,7 @@ impl Read for Stdin {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::io::{AsRawFd, RawFd};
 
     impl AsRawFd for Stdin {
@@ -194,7 +194,7 @@ crate::cfg_unix! {
     }
 }
 
-crate::cfg_windows! {
+cfg_windows! {
     use crate::os::windows::io::{AsRawHandle, RawHandle};
 
     impl AsRawHandle for Stdin {

--- a/src/io/stdout.rs
+++ b/src/io/stdout.rs
@@ -160,7 +160,7 @@ impl Write for Stdout {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::io::{AsRawFd, RawFd};
 
     impl AsRawFd for Stdout {
@@ -170,7 +170,7 @@ crate::cfg_unix! {
     }
 }
 
-crate::cfg_windows! {
+cfg_windows! {
     use crate::os::windows::io::{AsRawHandle, RawHandle};
 
     impl AsRawHandle for Stdout {

--- a/src/io/write/mod.rs
+++ b/src/io/write/mod.rs
@@ -12,7 +12,7 @@ use write_vectored::WriteVectoredFuture;
 
 use crate::io::{self, IoSlice};
 
-crate::extension_trait! {
+extension_trait! {
     use std::pin::Pin;
     use std::ops::{Deref, DerefMut};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,8 @@
 #![doc(html_logo_url = "https://async.rs/images/logo--hero.svg")]
 #![recursion_limit = "1024"]
 
-pub(crate) mod utils;
+#[macro_use]
+mod utils;
 
 pub mod fs;
 pub mod future;

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -7,13 +7,13 @@ use crate::future::Future;
 use crate::io;
 use crate::task::{blocking, Context, JoinHandle, Poll};
 
-crate::cfg_not_docs! {
+cfg_not_docs! {
     macro_rules! ret {
         (impl Future<Output = $out:ty>, $fut:ty) => ($fut);
     }
 }
 
-crate::cfg_docs! {
+cfg_docs! {
     #[doc(hidden)]
     pub struct ImplFuture<T>(std::marker::PhantomData<T>);
 

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -210,7 +210,7 @@ impl From<std::net::TcpListener> for TcpListener {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
     impl AsRawFd for TcpListener {
@@ -232,7 +232,7 @@ crate::cfg_unix! {
     }
 }
 
-crate::cfg_windows! {
+cfg_windows! {
     // use crate::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
     //
     // impl AsRawSocket for TcpListener {

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -365,7 +365,7 @@ impl From<std::net::TcpStream> for TcpStream {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
     impl AsRawFd for TcpStream {
@@ -387,7 +387,7 @@ crate::cfg_unix! {
     }
 }
 
-crate::cfg_windows! {
+cfg_windows! {
     // use crate::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
     //
     // impl AsRawSocket for TcpStream {

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -461,7 +461,7 @@ impl From<std::net::UdpSocket> for UdpSocket {
     }
 }
 
-crate::cfg_unix! {
+cfg_unix! {
     use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
     impl AsRawFd for UdpSocket {
@@ -483,7 +483,7 @@ crate::cfg_unix! {
     }
 }
 
-crate::cfg_windows! {
+cfg_windows! {
     // use crate::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
     //
     // impl AsRawSocket for UdpSocket {

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,9 +1,9 @@
 //! OS-specific extensions.
 
-crate::cfg_unix! {
+cfg_unix! {
     pub mod unix;
 }
 
-crate::cfg_windows! {
+cfg_windows! {
     pub mod windows;
 }

--- a/src/os/unix/fs.rs
+++ b/src/os/unix/fs.rs
@@ -29,11 +29,11 @@ pub async fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Resu
     blocking::spawn(move || std::os::unix::fs::symlink(&src, &dst)).await
 }
 
-crate::cfg_not_docs! {
+cfg_not_docs! {
     pub use std::os::unix::fs::{DirBuilderExt, DirEntryExt, OpenOptionsExt};
 }
 
-crate::cfg_docs! {
+cfg_docs! {
     /// Unix-specific extensions to `DirBuilder`.
     pub trait DirBuilderExt {
         /// Sets the mode to create new directories with. This option defaults to

--- a/src/os/unix/io.rs
+++ b/src/os/unix/io.rs
@@ -1,10 +1,10 @@
 //! Unix-specific I/O extensions.
 
-crate::cfg_not_docs! {
+cfg_not_docs! {
     pub use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 }
 
-crate::cfg_docs! {
+cfg_docs! {
     /// Raw file descriptors.
     pub type RawFd = std::os::raw::c_int;
 

--- a/src/os/unix/net/mod.rs
+++ b/src/os/unix/net/mod.rs
@@ -8,11 +8,11 @@ mod datagram;
 mod listener;
 mod stream;
 
-crate::cfg_not_docs! {
+cfg_not_docs! {
     pub use std::os::unix::net::SocketAddr;
 }
 
-crate::cfg_docs! {
+cfg_docs! {
     use std::fmt;
 
     use crate::path::Path;

--- a/src/os/windows/io.rs
+++ b/src/os/windows/io.rs
@@ -1,12 +1,12 @@
 //! Windows-specific I/O extensions.
 
-crate::cfg_not_docs! {
+cfg_not_docs! {
     pub use std::os::windows::io::{
         AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle, RawSocket,
     };
 }
 
-crate::cfg_docs! {
+cfg_docs! {
     /// Raw HANDLEs.
     pub type RawHandle = *mut std::os::raw::c_void;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,7 +39,7 @@ pub use crate::io::write::WriteExt as _;
 #[doc(hidden)]
 pub use crate::stream::stream::StreamExt as _;
 
-crate::cfg_unstable! {
+cfg_unstable! {
     #[doc(no_inline)]
     pub use crate::stream::DoubleEndedStream;
     #[doc(no_inline)]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -38,7 +38,7 @@ mod once;
 mod repeat;
 mod repeat_with;
 
-crate::cfg_unstable! {
+cfg_unstable! {
     mod double_ended_stream;
     mod exact_size_stream;
     mod extend;

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -91,7 +91,7 @@ pub use zip::Zip;
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 
-crate::cfg_unstable! {
+cfg_unstable! {
     use std::pin::Pin;
 
     use crate::future::Future;
@@ -102,7 +102,7 @@ crate::cfg_unstable! {
     mod merge;
 }
 
-crate::extension_trait! {
+extension_trait! {
     use std::ops::{Deref, DerefMut};
 
     use crate::task::{Context, Poll};
@@ -485,7 +485,7 @@ crate::extension_trait! {
             #
             # }) }
             ```
-            
+
         "#]
         fn last(
             self,
@@ -1335,9 +1335,9 @@ crate::extension_trait! {
             let s4 = VecDeque::from(vec![1, 2, 4]);
             assert_eq!(s1.clone().partial_cmp(s1.clone()).await, Some(Ordering::Equal));
             assert_eq!(s1.clone().partial_cmp(s2.clone()).await, Some(Ordering::Less));
-            assert_eq!(s2.clone().partial_cmp(s1.clone()).await, Some(Ordering::Greater));       
+            assert_eq!(s2.clone().partial_cmp(s1.clone()).await, Some(Ordering::Greater));
             assert_eq!(s3.clone().partial_cmp(s4.clone()).await, Some(Ordering::Less));
-            assert_eq!(s4.clone().partial_cmp(s3.clone()).await, Some(Ordering::Greater));                             
+            assert_eq!(s4.clone().partial_cmp(s3.clone()).await, Some(Ordering::Greater));
             #
             # }) }
             ```
@@ -1356,7 +1356,7 @@ crate::extension_trait! {
 
         #[doc = r#"
             Lexicographically compares the elements of this `Stream` with those
-            of another using 'Ord'. 
+            of another using 'Ord'.
 
             # Examples
 
@@ -1373,9 +1373,9 @@ crate::extension_trait! {
             let s4 = VecDeque::from(vec![1, 2, 4]);
             assert_eq!(s1.clone().cmp(s1.clone()).await, Ordering::Equal);
             assert_eq!(s1.clone().cmp(s2.clone()).await, Ordering::Less);
-            assert_eq!(s2.clone().cmp(s1.clone()).await, Ordering::Greater);       
+            assert_eq!(s2.clone().cmp(s1.clone()).await, Ordering::Greater);
             assert_eq!(s3.clone().cmp(s4.clone()).await, Ordering::Less);
-            assert_eq!(s4.clone().cmp(s3.clone()).await, Ordering::Greater);  
+            assert_eq!(s4.clone().cmp(s3.clone()).await, Ordering::Greater);
             #
             # }) }
             ```

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -38,7 +38,7 @@ pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 mod mutex;
 mod rwlock;
 
-crate::cfg_unstable! {
+cfg_unstable! {
     pub use barrier::{Barrier, BarrierWaitResult};
     mod barrier;
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -143,7 +143,7 @@ mod worker;
 
 pub(crate) mod blocking;
 
-crate::cfg_unstable! {
+cfg_unstable! {
     mod yield_now;
     pub use yield_now::yield_now;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,7 +22,6 @@ pub fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
 
 /// Declares unstable items.
 #[doc(hidden)]
-#[macro_export]
 macro_rules! cfg_unstable {
     ($($item:item)*) => {
         $(
@@ -35,7 +34,6 @@ macro_rules! cfg_unstable {
 
 /// Declares Unix-specific items.
 #[doc(hidden)]
-#[macro_export]
 macro_rules! cfg_unix {
     ($($item:item)*) => {
         $(
@@ -48,7 +46,6 @@ macro_rules! cfg_unix {
 
 /// Declares Windows-specific items.
 #[doc(hidden)]
-#[macro_export]
 macro_rules! cfg_windows {
     ($($item:item)*) => {
         $(
@@ -61,7 +58,6 @@ macro_rules! cfg_windows {
 
 /// Declares items when the "docs" feature is enabled.
 #[doc(hidden)]
-#[macro_export]
 macro_rules! cfg_docs {
     ($($item:item)*) => {
         $(
@@ -73,7 +69,6 @@ macro_rules! cfg_docs {
 
 /// Declares items when the "docs" feature is disabled.
 #[doc(hidden)]
-#[macro_export]
 macro_rules! cfg_not_docs {
     ($($item:item)*) => {
         $(
@@ -92,7 +87,6 @@ macro_rules! cfg_not_docs {
 /// Inside invocations of this macro, we write a definitions that looks similar to the final
 /// rendered docs, and the macro then generates all the boilerplate for us.
 #[doc(hidden)]
-#[macro_export]
 macro_rules! extension_trait {
     (
         // Interesting patterns:
@@ -129,7 +123,7 @@ macro_rules! extension_trait {
         #[cfg(feature = "docs")]
         #[doc = $doc]
         pub trait $name {
-            crate::extension_trait!(@doc () $($body_base)* $($body_ext)*);
+            extension_trait!(@doc () $($body_base)* $($body_ext)*);
         }
 
         // When not rendering docs, re-export the base trait from the futures crate.
@@ -139,7 +133,7 @@ macro_rules! extension_trait {
         // The extension trait that adds methods to any type implementing the base trait.
         /// Extension trait.
         pub trait $ext: $base {
-            crate::extension_trait!(@ext () $($body_ext)*);
+            extension_trait!(@ext () $($body_ext)*);
         }
 
         // Blanket implementation of the extension trait for any type implementing the base trait.
@@ -151,26 +145,26 @@ macro_rules! extension_trait {
 
     // Parse the return type in an extension method.
     (@doc ($($head:tt)*) -> impl Future<Output = $out:ty> [$f:ty] $($tail:tt)*) => {
-        crate::extension_trait!(@doc ($($head)* -> owned::ImplFuture<$out>) $($tail)*);
+        extension_trait!(@doc ($($head)* -> owned::ImplFuture<$out>) $($tail)*);
     };
     (@ext ($($head:tt)*) -> impl Future<Output = $out:ty> $(+ $lt:lifetime)? [$f:ty] $($tail:tt)*) => {
-        crate::extension_trait!(@ext ($($head)* -> $f) $($tail)*);
+        extension_trait!(@ext ($($head)* -> $f) $($tail)*);
     };
 
     // Parse the return type in an extension method.
     (@doc ($($head:tt)*) -> impl Future<Output = $out:ty> + $lt:lifetime [$f:ty] $($tail:tt)*) => {
-        crate::extension_trait!(@doc ($($head)* -> borrowed::ImplFuture<$lt, $out>) $($tail)*);
+        extension_trait!(@doc ($($head)* -> borrowed::ImplFuture<$lt, $out>) $($tail)*);
     };
     (@ext ($($head:tt)*) -> impl Future<Output = $out:ty> + $lt:lifetime [$f:ty] $($tail:tt)*) => {
-        crate::extension_trait!(@ext ($($head)* -> $f) $($tail)*);
+        extension_trait!(@ext ($($head)* -> $f) $($tail)*);
     };
 
     // Parse a token.
     (@doc ($($head:tt)*) $token:tt $($tail:tt)*) => {
-        crate::extension_trait!(@doc ($($head)* $token) $($tail)*);
+        extension_trait!(@doc ($($head)* $token) $($tail)*);
     };
     (@ext ($($head:tt)*) $token:tt $($tail:tt)*) => {
-        crate::extension_trait!(@ext ($($head)* $token) $($tail)*);
+        extension_trait!(@ext ($($head)* $token) $($tail)*);
     };
 
     // Handle the end of the token list.
@@ -182,6 +176,6 @@ macro_rules! extension_trait {
         #[cfg(feature = "docs")]
         $import
 
-        crate::extension_trait!($($tail)*);
+        extension_trait!($($tail)*);
     };
 }


### PR DESCRIPTION
Addressed https://github.com/async-rs/async-std/pull/361#discussion_r335985419

* Apply `#[macro_use]` to the module where the macro is defined.
* Remove `crate::` from all internal macro calls.
* Remove `#[macro_export]` from the internal macro.

r? @stjepang 